### PR TITLE
Exit for invalid requests but rety for 429 too many requests

### DIFF
--- a/run_input.py
+++ b/run_input.py
@@ -176,7 +176,7 @@ def pull_via_hydrocron(reach_or_node, id_of_interest, fields, date_range, api_ke
 
         # check for errors
         elif 'error' in data.keys():
-            if '4' in data['error']:
+            if '400' in data['error']:
                 logging.error('Invalid request made to Hydrocron: %s. Exiting...', data['error'])
                 sys.exit(1)
             retry_cnt += 1


### PR DESCRIPTION
Only exit when a '400' error is encountered as we cannot recover from an invalid request. Otherwise retry which should cover the '429 Too Many Requests' error that gets returned when burst and rate limits are exceeded.