### PR TITLE
H break bugfix

### DIFF
--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -96,6 +96,8 @@ class CalculateHWS:
         print("main function before constrainHW")
         print(self.area_fit['h_break'])
         self.ConstrainHW()
+        print("main function after constrainHW")
+        print(self.area_fit['h_break'])
 
         # if self.Verbose:
         #     self.plotHW()

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -95,7 +95,10 @@ class CalculateHWS:
         # 3 constrain heights and widths to be self-consistent
         print("main function before constrainHW")
         print(self.area_fit['h_break'])
-        self.ConstrainHW()
+        if self.fit_status:
+            print('skipping HW_constraint due to static fit beingg triggered')
+        else:
+            self.ConstrainHW()
         print("main function after constrainHW")
         print(self.area_fit['h_break'])
 
@@ -219,7 +222,7 @@ class CalculateHWS:
                  self.w[0,:]=what[0,:]
 
             print('in constrain before hbreak reset')
-            print(self.area_fit['h_break'])
+            print(self.area_fit['h_break'])            
             self.area_fit['h_break'][0]=np.nanmin(hhat)
             self.area_fit['h_break'][3]=np.nanmax(hhat)
             print('in constrain after hbreak reset')
@@ -460,6 +463,7 @@ class CalculateHWS:
              ReturnSolution=True
              Jset,p_inner_set=SSE_outer(init_params_outer,self.h[r,igoodhw],self.w[r,igoodhw],ReturnSolution,self.sigh,self.sigw,self.Verbose)
              # If set fit is implausible (slopes exceed arbitrary value), impose rectangular fit at median width
+             #0,1,2,3?
              if p_inner_set[0] > 10000 or p_inner_set[2] > 10000 or p_inner_set[4] > 10000:
                 print('Implausible set fit. Implementing rectangular fit.')
 
@@ -637,12 +641,12 @@ class CalculateHWS:
         Hbar=nanmedian(self.h[r,:])
         wbar=nanmedian(self.w[r,:])
 
-        dA_Hbar,hhat,what,dAunc=area(Hbar, wbar, area_fit)
+        #dA_Hbar,hhat,what,dAunc=area(Hbar, wbar, area_fit)
 
         area_fit['med_flow_area']=dA_Hbar
         #Check fit for errors
         status=self.do_area_fit_checks(area_fit)
-        
+        self.fit_status=status
         if status:
             print("fit requires modification")
             area_fit=self.correct_fit_params(area_fit)
@@ -651,6 +655,9 @@ class CalculateHWS:
         else:
             print("fit does not require modification")
 
+        dA_Hbar,hhat,what,dAunc=area(Hbar, wbar, area_fit)
+        print('Da_Hbar')
+        print(dA_Hbar)
         #4.6 save fit data
         self.area_fit=area_fit
         print("after save")

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -93,6 +93,8 @@ class CalculateHWS:
             #    dAOpt=-1 
         
         # 3 constrain heights and widths to be self-consistent
+        print("main function before constrainHW")
+        print(self.area_fit['h_break'])
         self.ConstrainHW()
 
         # if self.Verbose:
@@ -640,7 +642,7 @@ class CalculateHWS:
             print("fit requires modification")
             area_fit=self.correct_fit_params(area_fit)
             print("fit set to static values")
-            print(area_fit['h_break'])
+            print(self.area_fit['h_break'])
         else:
             print("fit does not require modification")
 

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -697,7 +697,10 @@ class CalculateHWS:
         wse_valid_max=150000
         hb=area_fit['h_break']
         hb_=np.linspace(wse_valid_min,wse_valid_max,len(hb))
-        area_fit['h_break']=hb_
+        for b in range(len(hb_)):
+            area_fit['h_break'][b]=hb_[b]
+
+        #area_fit['h_break']=hb_
         print(area_fit['h_break'])
         #
         print('set slopes to zero')

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -640,6 +640,7 @@ class CalculateHWS:
             print("fit requires modification")
             area_fit=self.correct_fit_params(area_fit)
             print("fit set to static values")
+            print(area_fit['h_break'])
         else:
             print("fit does not require modification")
 

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -642,12 +642,14 @@ class CalculateHWS:
             print("fit requires modification")
             area_fit=self.correct_fit_params(area_fit)
             print("fit set to static values")
-            print(self.area_fit['h_break'])
+            
         else:
             print("fit does not require modification")
 
         #4.6 save fit data
         self.area_fit=area_fit
+        print("after save")
+        print(self.area_fit['h_break'])
 
         #if self.Verbose:
             #print('area fit parameters=',self.area_fit)

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -643,7 +643,7 @@ class CalculateHWS:
 
         #dA_Hbar,hhat,what,dAunc=area(Hbar, wbar, area_fit)
 
-        area_fit['med_flow_area']=dA_Hbar
+        #area_fit['med_flow_area']=dA_Hbar
         #Check fit for errors
         status=self.do_area_fit_checks(area_fit)
         self.fit_status=status
@@ -656,6 +656,7 @@ class CalculateHWS:
             print("fit does not require modification")
 
         dA_Hbar,hhat,what,dAunc=area(Hbar, wbar, area_fit)
+        area_fit['med_flow_area']=dA_Hbar
         print('Da_Hbar')
         print(dA_Hbar)
         #4.6 save fit data

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -218,9 +218,12 @@ class CalculateHWS:
                  self.h[0,:]=hhat[0,:]
                  self.w[0,:]=what[0,:]
 
-            
+            print('in constrain before hbreak reset')
+            print(self.area_fit['h_break'])
             self.area_fit['h_break'][0]=np.nanmin(hhat)
             self.area_fit['h_break'][3]=np.nanmax(hhat)
+            print('in constrain after hbreak reset')
+            print(self.area_fit['h_break'])
                 
 
     def MapPointToHypsometricCurve(self,h,w):

--- a/input/extract/CalculateHWS.py
+++ b/input/extract/CalculateHWS.py
@@ -246,28 +246,28 @@ class CalculateHWS:
                 hhat=hhatsd
                 what=whatsd
 
-        if np.isnan(hhat) and self.Verbose:
-            print('data point did not map to a valid sub-domain...')
-        #Find closest breakpoint to h
-        close_break = np.argmin(np.abs(self.area_fit['h_break'] - h))
+            if np.isnan(hhat) and self.Verbose:
+                print('data point did not map to a valid sub-domain...')
+            #Find closest breakpoint to h
+            close_break = np.argmin(np.abs(self.area_fit['h_break'] - h))
 
-        # If hhat is beyond the maximum observed h, map point to final breakpoint
-        if close_break == 3:
+            # If hhat is beyond the maximum observed h, map point to final breakpoint
+            if close_break == 3:
 
-            # Retrieve final region fit
-            p0 = self.area_fit['fit_coeffs'][1, close_break-1, 0]  # intercept
-            p1 = self.area_fit['fit_coeffs'][0, close_break-1, 0]  # slope
+                # Retrieve final region fit
+                p0 = self.area_fit['fit_coeffs'][1, close_break-1, 0]  # intercept
+                p1 = self.area_fit['fit_coeffs'][0, close_break-1, 0]  # slope
 
-        # Get fit from region nearest to h
-        else:
+            # Get fit from region nearest to h
+            else:
 
-            # Retrieve region fit
-            p0 = self.area_fit['fit_coeffs'][1, close_break, 0]  # intercept
-            p1 = self.area_fit['fit_coeffs'][0, close_break, 0]  # slope
+                # Retrieve region fit
+                p0 = self.area_fit['fit_coeffs'][1, close_break, 0]  # intercept
+                p1 = self.area_fit['fit_coeffs'][0, close_break, 0]  # slope
 
-            # Map point to intersection of subdomain fit and breakpoint
-            hhat = self.area_fit['h_break'][close_break]
-            what = p0 + p1 * hhat
+                # Map point to intersection of subdomain fit and breakpoint
+                hhat = self.area_fit['h_break'][close_break]
+                what = p0 + p1 * hhat
 
         return hhat,what
                     


### PR DESCRIPTION
In integrator testing we discovered a high number of reaches that were populated with no dx_area, but had plenty of wse and width measurements. This commit solves several minor bugs as well as bypassing the HWconstraint function when the static fit parameter is set. This prevents HWconstraint from resetting the static area fits and breaking them. Every change here is internal to input and should not have downstream impacts aside from more populated dx_area in the timeseries files.